### PR TITLE
I've updated the GitHub Actions in your build workflow. Specifically,…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -28,7 +28,7 @@ jobs:
         run: pyinstaller --onefile --windowed --icon=icon.ico IPTV_Manager_Pro.py
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: IPTV-Manager-Pro-Windows
           path: dist/IPTV_Manager_Pro.exe
@@ -37,7 +37,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -53,7 +53,7 @@ jobs:
         run: pyinstaller --onefile --windowed --icon=icon.ico IPTV_Manager_Pro.py
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: IPTV-Manager-Pro-macOS
           path: dist/IPTV_Manager_Pro


### PR DESCRIPTION
… I've upgraded `actions/checkout` and `actions/upload-artifact` to `v4` to fix the deprecation error.