### PR TITLE
feat: Build universal macOS application

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: Run PyInstaller
-        run: pyinstaller --windowed --icon=icon.ico IPTV_Manager_Pro.py
+        run: pyinstaller --onedir --windowed --icon=icon.ico --target-arch=universal2 IPTV_Manager_Pro.py
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
- Adds the `--target-arch=universal2` flag to the PyInstaller command in the GitHub Actions workflow.
- This ensures that the macOS build produces a universal binary that runs on both Apple Silicon and Intel Macs.