### PR TITLE
fix: Simplify PyInstaller command for macOS build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: Run PyInstaller
-        run: pyinstaller --onedir --windowed --icon=icon.ico --target-arch=universal2 IPTV_Manager_Pro.py
+        run: pyinstaller --onedir --windowed --target-arch=universal2 IPTV_Manager_Pro.py
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
- Temporarily removes the `--icon` flag from the PyInstaller command in the GitHub Actions workflow.
- This is to diagnose the issue where the `.app` bundle closes immediately after launching.