### PR TITLE
Fix QFont point-size warnings and QThread destruction race

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,59 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+Development is on Windows. A `.venv` exists in the repo root.
+
+```powershell
+# Install deps
+.\.venv\Scripts\python.exe -m pip install -r requirements.txt
+
+# Run the app
+.\.venv\Scripts\python.exe IPTV_Manager_Pro.py
+
+# Build the Windows exe (matches CI in .github/workflows/build.yml)
+pyinstaller --onefile --windowed --icon=icon.ico --add-data "icon.ico;." IPTV_Manager_Pro.py
+```
+
+There is no test suite, no linter config, and no packaging metadata (no `pyproject.toml` / `setup.py`). CI only builds the PyInstaller artifact on push to `main` and on a 10-day cron.
+
+The app is portable: `iptv_store.db`, `iptv_manager_log.txt` (opened with `filemode='w'` — wiped each run), and `settings.json` are created in the working directory at runtime.
+
+## Architecture
+
+PySide6 desktop app for managing/checking IPTV credentials. Two account types are first-class: **Xtream Codes API** (`account_type='xc'`) and **Stalker Portal** (`account_type='stalker'`, identified by portal URL + MAC). Most logic conditions on this discriminator — when adding features, both branches generally need handling.
+
+### Module layout (flat, no package)
+
+- **`IPTV_Manager_Pro.py`** (~2700 lines, monolithic) — UI, sqlite persistence, all `QDialog`s, the `MainWindow`, and a fleet of `QObject` worker classes that get moved onto `QThread`s for background work (category loading, stream loading, series info, playback, EPG, API checking). Worker→thread wiring is hand-rolled; when adding a worker, follow the existing pattern (worker emits `finished`/`error` signals, thread is `quit`/`wait`ed in slots).
+- **`core_checker.py`** — `IPTVChecker` class, the **async** (`aiohttp`) credential-checker engine. Two-tier: API check, then optional stream playability check (download speed test, FFmpeg fallback). Implements the "frozen account" backoff (failures → exponential skip windows) referenced in the README. Called from `ApiCheckerWorker` in the main file via `asyncio.run` inside a QThread.
+- **`stalker_integration.py`** — `StalkerPortal` class, **synchronous** (`requests`) Stalker client used by all Qt worker threads (handshake, profile, EPG, stream link resolution). The async checker in `core_checker.py` has its own parallel Stalker implementation; **the two must stay behaviorally consistent** (same handshake quirks, same URL normalization, same MAG user-agent). `MAG_USER_AGENT` is shared via re-export.
+- **`epg_manager.py`** — `EpgManager(QThread)` with its own `StalkerPortal` session, drained from a queue. UI requests EPG via `request_epg(channel_id)`; results come back via the `epg_ready(channel_id, data)` signal.
+- **`companion_utils.py`** — `resource_path` (PyInstaller `_MEIPASS` aware), `MediaPlayerManager` (locates/launches FFplay or MPV), and `ThemeManager` (singleton; loads QSS from `styles/` per `styles/themes.json`).
+
+### Data model
+
+SQLite, schema initialized in `initialize_database()` in the main file. The same `entries` table holds both account types — Xtream fields (`server_url`, `username`, `password`) and Stalker fields (`portal_url`, `mac_address`) coexist as nullable columns. `account_type` discriminates. Status fields (`expiry_date_ts`, `is_trial`, `active_connections`, etc.) are written by `update_entry_status` after a check.
+
+### Concurrency model
+
+- UI thread: Qt event loop only.
+- Bulk credential checks: `ApiCheckerWorker` runs an `asyncio` loop on a `QThread`, fans out to `IPTVChecker` (aiohttp). Progress reported via Qt signals.
+- All other background work (Stalker browsing, playback resolution, EPG): one `QObject` worker per task, `moveToThread` onto a fresh `QThread`. These use the **synchronous** `StalkerPortal`/`requests` — do not mix the async checker into UI worker paths.
+
+### Theming
+
+QSS is external in `styles/dark.qss` and `styles/light.qss`, indexed by `styles/themes.json`. `ThemeManager` is a singleton with a QSS cache; switch themes through it, do not call `setStyleSheet` directly on widgets.
+
+### Stalker portal specifics
+
+The codebase has substantial accumulated knowledge about Stalker portal quirks documented in:
+- `stalker-knowledge-base.md`, `Stalker-Portal-Playback-Features.md`, `iptv-manager-pro-guide-for-stalker-playback.md`, `iptv-manager-pro-stalker-portal-fix-plan.md`
+
+Read these before modifying Stalker handshake, token handling, URL normalization, or stream-link resolution — there are workarounds for specific portal variants that aren't obvious from the code alone.
+
+## License note
+
+The project uses Apache 2.0 + Commons Clause + an Acceptable Use Policy (see `LICENSE`). It is source-available, **not** OSI-open-source: no commercial sale/hosting. Worth flagging if a change has licensing implications.

--- a/IPTV_Manager_Pro.py
+++ b/IPTV_Manager_Pro.py
@@ -1284,11 +1284,11 @@ class PlaylistBrowserDialog(QDialog):
     @Slot(QTreeWidgetItem, int)
     def on_category_clicked(self, item, column):
         # Stop any existing worker threads before starting a new one
-        if self.stream_worker_thread and self.stream_worker_thread.isRunning():
+        if self.stream_worker_thread:
             self.stream_worker_thread.quit()
-            self.stream_worker_thread.wait() # Wait for the thread to finish
+            self.stream_worker_thread.wait()
 
-        if self.series_info_thread and self.series_info_thread.isRunning():
+        if self.series_info_thread:
             self.series_info_thread.quit()
             self.series_info_thread.wait()
 
@@ -1438,9 +1438,9 @@ class PlaylistBrowserDialog(QDialog):
             self.playback_worker.moveToThread(self.playback_thread)
             self.playback_worker.link_ready.connect(self.launch_stalker_player)
             self.playback_worker.error_occurred.connect(self.on_load_error)
+            self.playback_worker.finished.connect(self.playback_thread.quit)
+            self.playback_worker.finished.connect(self.playback_worker.deleteLater)
             self.playback_thread.started.connect(self.playback_worker.run)
-            # Connecting finished to deleteLater is unsafe here as we manage lifecycle manually
-            # self.playback_thread.finished.connect(self.playback_thread.deleteLater)
             self.playback_thread.start()
             return
 
@@ -1461,9 +1461,9 @@ class PlaylistBrowserDialog(QDialog):
     @Slot(str, str)
     def launch_stalker_player(self, url, cookies):
         self.status_label.setText("Launching player...")
-        if self.playback_thread and self.playback_thread.isRunning():
+        if self.playback_thread:
             self.playback_thread.quit()
-            self.playback_thread.wait() # Ensure it stops
+            self.playback_thread.wait()
 
         # Ensure Referer ends with /c/ as per MAG standard
         portal_url = self.entry_data.get('portal_url', '')
@@ -1485,7 +1485,7 @@ class PlaylistBrowserDialog(QDialog):
         self.media_player_manager.play_stream(stream_url, self, referer_url=server)
 
     def fetch_series_episodes(self, series_id):
-        if self.series_info_thread and self.series_info_thread.isRunning():
+        if self.series_info_thread:
             self.series_info_thread.quit()
             self.series_info_thread.wait()
 
@@ -1562,18 +1562,11 @@ class PlaylistBrowserDialog(QDialog):
         self.series_info_thread.quit()
 
     def closeEvent(self, event):
-        if self.category_worker_thread and self.category_worker_thread.isRunning():
-            self.category_worker_thread.quit()
-            self.category_worker_thread.wait()
-        if self.stream_worker_thread and self.stream_worker_thread.isRunning():
-            self.stream_worker_thread.quit()
-            self.stream_worker_thread.wait()
-        if self.series_info_thread and self.series_info_thread.isRunning():
-            self.series_info_thread.quit()
-            self.series_info_thread.wait()
-        if self.playback_thread and self.playback_thread.isRunning():
-            self.playback_thread.quit()
-            self.playback_thread.wait()
+        for thread in (self.category_worker_thread, self.stream_worker_thread,
+                       self.series_info_thread, self.playback_thread):
+            if thread:
+                thread.quit()
+                thread.wait()
 
         if hasattr(self, 'epg_manager') and self.epg_manager.isRunning():
             self.epg_manager.stop()

--- a/styles/dark.qss
+++ b/styles/dark.qss
@@ -3,7 +3,7 @@
 QWidget {
     background-color: #2b2b2b;
     color: #efefef;
-    font-size: 13px;
+    font-size: 10pt;
 }
 
 QMainWindow, QDialog {

--- a/styles/light.qss
+++ b/styles/light.qss
@@ -3,7 +3,7 @@
 QWidget {
     background-color: #f0f0f0;
     color: #333;
-    font-size: 13px;
+    font-size: 10pt;
 }
 
 QMainWindow, QDialog {


### PR DESCRIPTION
- styles: change font-size from 13px to 10pt in both themes; pixel-sized fonts return -1 from pointSize(), which Qt passes to setPointSize() during style propagation, producing the warning on every theme load.

- PlaylistBrowserDialog: add playback_worker.finished -> playback_thread.quit connection so the playback thread's event loop exits naturally after the worker returns, instead of spinning until the object is destroyed.

- Remove isRunning() guards from all quit()/wait() call sites (closeEvent, on_category_clicked, fetch_series_episodes, launch_stalker_player). Qt clears isRunning when the event loop exits, but the OS thread is still winding down; skipping wait() in that window caused the destructor to fire while the thread was alive. Both quit() and wait() are safe to call unconditionally on any QThread state.

- Add CLAUDE.md with build commands and architecture overview.